### PR TITLE
🎈 perf: Improve compatibility of signal handler and make ping command response ephemeral

### DIFF
--- a/src/Fisher/cogs/CoreCog.py
+++ b/src/Fisher/cogs/CoreCog.py
@@ -42,8 +42,9 @@ class CoreCog(
         },
     )
     async def ping(self, interaction: Interaction) -> None:
-        await interaction.response.send_message(
-            f"Pong! Latency: {self.bot.latency * 1000:.2f}ms"
+        await interaction.response.defer(ephemeral=True)
+        await interaction.followup.send(
+            f"Pong! Latency: {self.bot.latency * 1000:.2f}ms", ephemeral=True
         )
 
     @app_commands.command(


### PR DESCRIPTION
This pull request includes two commits that aim to improve performance and user experience.

The first commit "perf: Use loop.add_signal_handler as default and use signal module if the previous one is not supported" updates the signal handling mechanism in the code. It uses `loop.add_signal_handler` as the default method for handling signals and falls back to the `signal` module if the former is not supported. This change ensures better compatibility and performance.

The second commit "perf: Make ping command response ephemeral" improves the ping command response. Instead of immediately sending the response message, it defers the response and sends it as an ephemeral message. This change enhances the user experience by reducing clutter in the chat and making the response more focused.

Overall, these changes aim to optimize the code and provide a smoother user experience.